### PR TITLE
Unify wiki sidebar with main editor

### DIFF
--- a/src/components/fiction/EditorAreaFiction.tsx
+++ b/src/components/fiction/EditorAreaFiction.tsx
@@ -86,6 +86,32 @@ const EditorAreaFiction: React.FC<EditorAreaFictionProps> = ({
     setTags(tags.filter(tag => tag !== tagToRemove));
   };
 
+  const renderers = useMemo(() => ({
+    text: ({ children }: { children: string }) => {
+      const tokens = children.split(/(\s+)/);
+      return (
+        <>
+          {tokens.map((token, idx) => {
+            const clean = token.replace(/[^\w]/g, '');
+            if (knownTerms[clean]) {
+              return (
+                <TermHighlight
+                  key={idx}
+                  termKey={clean}
+                  onMouseEnter={onTermHover}
+                  onMouseLeave={onTermLeave}
+                >
+                  {token}
+                </TermHighlight>
+              );
+            }
+            return <React.Fragment key={idx}>{token}</React.Fragment>;
+          })}
+        </>
+      );
+    },
+  }), [knownTerms, onTermHover, onTermLeave]);
+
   return (
     <main className={styles.editorArea}>
       <div className={styles.toolbar}>
@@ -132,7 +158,7 @@ const EditorAreaFiction: React.FC<EditorAreaFictionProps> = ({
               />
             ) : (
               <div className={styles.contentViewerText}>
-                 <ReactMarkdown>{editableContent}</ReactMarkdown>
+                 <ReactMarkdown components={renderers}>{editableContent}</ReactMarkdown>
               </div>
             )}
              {isEditing && (

--- a/src/components/fiction/SidebarFiction.tsx
+++ b/src/components/fiction/SidebarFiction.tsx
@@ -40,23 +40,27 @@ const SidebarFiction: React.FC<SidebarFictionProps> = ({ isMobileMenuOpen, title
       </div>
 
       <div className={styles.buttonGroup}>
-        <button className={`button-base ${styles.activeButton}`}>Codex</button>
-        <button className={`button-base ${styles.inactiveButton}`}>Snippets</button>
-        <button className={`button-base ${styles.inactiveButton}`}>Chats</button>
-        <PlusCircle className={styles.plusIcon} onClick={() => alert("Add new entry!")} />
+        <button className={`button-base ${styles.activeButton}`} onClick={() => alert('Codex clicked')}>Codex</button>
+        <button className={`button-base ${styles.inactiveButton}`} onClick={() => alert('Snippets feature coming soon')}>Snippets</button>
+        <button className={`button-base ${styles.inactiveButton}`} onClick={() => alert('Chats feature coming soon')}>Chats</button>
+        <PlusCircle className={styles.plusIcon} onClick={() => alert('Add new entry!')} />
       </div>
 
       <nav className={styles.nav}>
         <ul>
           {navItems.map((item) => (
             <li key={item.name} className={styles.navItem}>
-              <a href="#" className={`${styles.navLink} ${item.active ? styles.navLinkActive : ''}`}>
+              <button
+                type="button"
+                className={`${styles.navLink} ${item.active ? styles.navLinkActive : ''}`}
+                onClick={() => alert(`${item.name} panel not implemented`)}
+              >
                 <div className={styles.navLinkContent}>
                   <item.icon className={`icon ${item.active ? styles.navIconActive : styles.navIcon}`} />
                   <span>{item.name}</span>
                 </div>
                 {item.count !== undefined && <span className={styles.navCount}>{item.count}</span>}
-              </a>
+              </button>
             </li>
           ))}
         </ul>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,12 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,38 +1,169 @@
-// src/pages/index.tsx
-
+import React, { useState, useEffect, useCallback } from 'react';
 import Head from 'next/head';
-import Link from 'next/link';
 import type { NextPage } from 'next';
-import styles from '../styles/Home.module.css';
+import { Menu, X } from 'lucide-react';
+import SidebarFiction from '../components/fiction/SidebarFiction';
+import EditorAreaFiction from '../components/fiction/EditorAreaFiction';
+import SidebarWiki from '../components/wiki/SidebarWiki';
+import WikiEditor from '../components/wiki/WikiEditor';
+import Tooltip from '../components/common/Tooltip';
+import type { FictionData, KnownTerms, WikiTerms, HoveredTermInfo } from '../types';
 
 const HomePage: NextPage = () => {
+  const [fictionData, setFictionData] = useState<FictionData>({ frontmatter: {}, markdownContent: '', wordCount: 0 });
+  const [knownTerms, setKnownTerms] = useState<KnownTerms>({});
+  const [hoveredTermInfo, setHoveredTermInfo] = useState<HoveredTermInfo | null>(null);
+  const [isTooltipVisible, setIsTooltipVisible] = useState<boolean>(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState<boolean>(false);
+  const [terms, setTerms] = useState<WikiTerms>({});
+  const [selectedTermKey, setSelectedTermKey] = useState<string | null>(null);
+  const [isWikiVisible, setIsWikiVisible] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const fetchFictionContent = async () => {
+    try {
+      const res = await fetch('/api/fiction/content');
+      if (!res.ok) throw new Error('Failed to fetch fiction content');
+      const data: FictionData = await res.json();
+      setFictionData(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const fetchTerms = async () => {
+    try {
+      const res = await fetch('/api/wiki/terms');
+      if (!res.ok) throw new Error('Failed to fetch wiki terms');
+      const data: WikiTerms = await res.json();
+      setTerms(data);
+      const formatted: KnownTerms = {};
+      for (const t in data) {
+        formatted[t] = data[t].description;
+      }
+      setKnownTerms(formatted);
+      if (Object.keys(data).length > 0) setSelectedTermKey(Object.keys(data)[0]);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    setIsLoading(true);
+    Promise.all([fetchFictionContent(), fetchTerms()]).finally(() => setIsLoading(false));
+  }, []);
+
+  const handleSaveContent = async (markdown: string, fm: typeof fictionData.frontmatter) => {
+    try {
+      const res = await fetch('/api/fiction/content', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ markdownContent: markdown, frontmatter: fm }),
+      });
+      if (!res.ok) throw new Error('Failed to save content');
+      const updated: FictionData = await res.json();
+      setFictionData(updated);
+      alert('Content saved!');
+    } catch (e) {
+      console.error('Save error:', e);
+      alert('Failed to save content.');
+    }
+  };
+
+  const handleSaveTerms = async (updated: WikiTerms): Promise<boolean> => {
+    try {
+      const res = await fetch('/api/wiki/terms', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updated),
+      });
+      if (!res.ok) throw new Error('Failed to save terms');
+      const result = await res.json();
+      setTerms(result.terms);
+      const formatted: KnownTerms = {};
+      for (const t in result.terms) {
+        formatted[t] = result.terms[t].description;
+      }
+      setKnownTerms(formatted);
+      alert('Wiki terms saved!');
+      return true;
+    } catch (e) {
+      console.error('Save error:', e);
+      alert('Failed to save wiki terms.');
+      return false;
+    }
+  };
+
+  const handleTermHover = useCallback((termKey: string, x: number, y: number) => {
+    const description = knownTerms[termKey] || 'No description available.';
+    setHoveredTermInfo({ term: termKey, description, x, y });
+    setIsTooltipVisible(true);
+  }, [knownTerms]);
+
+  const handleTermLeave = useCallback(() => {
+    setIsTooltipVisible(false);
+  }, []);
+
+  const handleSelectTerm = (key: string) => {
+    setSelectedTermKey(key);
+  };
+
+  const toggleMobileMenu = () => setIsMobileMenuOpen(!isMobileMenuOpen);
+
+  if (isLoading) {
+    return <div className="d-flex justify-content-center align-items-center vh-100">Loading...</div>;
+  }
+
   return (
-    <div className={styles.container}>
+    <div className="d-flex flex-column vh-100 bg-dark text-light">
       <Head>
-        <title>Feather App</title>
-        <meta name="description" content="Choose your mode" />
-        <link rel="icon" href="/favicon.ico" />
+        <title>Feather</title>
       </Head>
-
-      <main className={styles.main}>
-        <h1 className={styles.title}>Welcome to Feather</h1>
-        <p className={styles.description}>Select an interface to launch:</p>
-        <div className={styles.grid}>
-          <Link href="/fiction" legacyBehavior>
-            <a className={styles.card}>
-              <h2>Fiction Mode &rarr;</h2>
-              <p>Read and write your stories with interactive term highlighting.</p>
-            </a>
-          </Link>
-
-          <Link href="/wiki" legacyBehavior>
-            <a className={styles.card}>
-              <h2>Wiki Mode &rarr;</h2>
-              <p>Manage and explore your knowledge base for non-fiction content.</p>
-            </a>
-          </Link>
+      <header className="navbar navbar-dark bg-secondary sticky-top">
+        <div className="d-flex align-items-center">
+          <button onClick={toggleMobileMenu} className="btn btn-outline-light d-md-none me-2">
+            {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+          </button>
+          <h1 className="h5 mb-0">Feather / {fictionData.frontmatter?.title || 'Untitled'}</h1>
         </div>
-      </main>
+        <button onClick={() => setIsWikiVisible(!isWikiVisible)} className="btn btn-outline-light d-md-none">
+          {isWikiVisible ? 'Hide Wiki' : 'Show Wiki'}
+        </button>
+      </header>
+      <div className="d-flex flex-grow-1 overflow-hidden position-relative">
+        <SidebarFiction
+          isMobileMenuOpen={isMobileMenuOpen}
+          title={fictionData.frontmatter?.title || 'Untitled Document'}
+          currentWordCount={fictionData.wordCount}
+        />
+        {isMobileMenuOpen && (
+          <div className="position-fixed top-0 start-0 w-100 h-100" style={{ background: 'rgba(0,0,0,0.3)' }} onClick={() => setIsMobileMenuOpen(false)} />
+        )}
+        <EditorAreaFiction
+          initialContent={fictionData.markdownContent}
+          initialFrontmatter={fictionData.frontmatter}
+          knownTerms={knownTerms}
+          onTermHover={handleTermHover}
+          onTermLeave={handleTermLeave}
+          onSave={handleSaveContent}
+        />
+        <div className={`d-flex flex-column bg-secondary border-start overflow-auto ${isWikiVisible ? '' : 'd-none d-md-flex'}`} style={{ width: '20rem' }}>
+          <SidebarWiki
+            terms={terms}
+            onSelectTerm={handleSelectTerm}
+            selectedTermKey={selectedTermKey}
+            isMobileMenuOpen={false}
+          />
+          <WikiEditor
+            terms={terms}
+            selectedTermKey={selectedTermKey}
+            onSave={handleSaveTerms}
+            onSelectTerm={setSelectedTermKey}
+            setTerms={setTerms}
+          />
+        </div>
+      </div>
+      <Tooltip termInfo={hoveredTermInfo} isVisible={isTooltipVisible} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enable Bootstrap styling globally
- combine fiction editor and wiki editor into one page on `/`
- highlight wiki terms inside markdown content
- add placeholder alerts for sidebar navigation buttons

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fdd4539c8333ae79a01cd58eaa57