### PR TITLE
Add lucide icons to codex/snippets/chat buttons

### DIFF
--- a/src/components/fiction/SidebarFiction.module.css
+++ b/src/components/fiction/SidebarFiction.module.css
@@ -85,6 +85,11 @@
 .inactiveButton:hover {
   background-color: #334155; /* slate-700 */
 }
+.buttonIcon {
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.25rem;
+}
 .plusIcon {
   width: 1.25rem;
   height: 1.25rem;

--- a/src/components/fiction/SidebarFiction.tsx
+++ b/src/components/fiction/SidebarFiction.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import styles from './SidebarFiction.module.css';
-import { BookOpen, Users, MapPin, Package, Search, PlusCircle } from 'lucide-react';
+import { BookOpen, Users, MapPin, Package, Search, PlusCircle, FileText, MessageCircle } from 'lucide-react';
 
 interface SidebarFictionProps {
   isMobileMenuOpen: boolean;
@@ -40,9 +40,15 @@ const SidebarFiction: React.FC<SidebarFictionProps> = ({ isMobileMenuOpen, title
       </div>
 
       <div className={styles.buttonGroup}>
-        <button className={`button-base ${styles.activeButton}`}>Codex</button>
-        <button className={`button-base ${styles.inactiveButton}`}>Snippets</button>
-        <button className={`button-base ${styles.inactiveButton}`}>Chats</button>
+        <button className={`button-base ${styles.activeButton}`}>
+          <BookOpen size={14} className={styles.buttonIcon} /> Codex
+        </button>
+        <button className={`button-base ${styles.inactiveButton}`}>
+          <FileText size={14} className={styles.buttonIcon} /> Snippets
+        </button>
+        <button className={`button-base ${styles.inactiveButton}`}>
+          <MessageCircle size={14} className={styles.buttonIcon} /> Chats
+        </button>
         <PlusCircle className={styles.plusIcon} onClick={() => alert("Add new entry!")} />
       </div>
 


### PR DESCRIPTION
## Summary
- show icons next to sidebar buttons in fiction editor

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684206070404833188362bb402e71f81