### PR TITLE
Enhance wiki tooling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/pages/api-reference/create-next-app).
 
+This repository also demonstrates basic wiki editing utilities. See `docs/wiki-prompts.md` for guidance on how to process markdown and maintain a structured wiki.
+
 ## Getting Started
 
 First, run the development server:
@@ -38,3 +40,4 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
+

--- a/docs/wiki-prompts.md
+++ b/docs/wiki-prompts.md
@@ -1,0 +1,83 @@
+# Wiki Processing Guide
+
+This document outlines how language models should interact with the wiki files and fiction markdown. The wiki is stored as JSON in `src/data/wiki/terms.json` and fiction scenes are markdown files in `src/data/fiction`. The goal is to keep information consistent and easy to reference.
+
+## Numbering Sentences
+
+When saving a markdown scene, each sentence should be prefixed with its number in brackets. This allows sources in the wiki to reference exact sentences.
+
+Example:
+
+```
+[1] The stars hung low over the valley. [2] Our hero waited for dawn.
+```
+
+The numbering is created by the backend using `numberSentences()` from `src/utils/wikiProcessor.ts`.
+
+## Wiki Structure
+
+The wiki JSON contains terms as keys with a description and category. Terms are grouped logically, but the data file should remain simple so tools can load it easily. Recommended categories include:
+
+- **Character**
+- **Location**
+- **Object**
+- **Event**
+- **Trait** (for character traits or notable qualities)
+
+A template entry looks like:
+
+```json
+{
+  "Example Term": {
+    "description": "Brief explanation of the term.",
+    "category": "Character"
+  }
+}
+```
+
+Do not populate the wiki with specific story details here. Use placeholders so the structure is clear.
+
+## Using Tools with the Wiki
+
+Models can access the wiki through the `/api/wiki/terms` endpoint. Editing is done by sending the full JSON back to that endpoint. Sentence numbering can be generated with `/api/wiki/suggestions` when checking for inconsistencies.
+
+The `wikiProcessor` utility exports helper functions for splitting text into sentences, numbering them, and creating edit suggestions. See `src/utils/wikiProcessor.ts` for implementation details.
+
+## Prompt Examples
+
+Below are eight example prompts demonstrating different scenarios. Each response should use the JSON formats shown or numbered markdown as required.
+
+### 1. Update Wiki from New Snippet
+
+Input: a paragraph of text with new information. The model should extract new terms and return an updated wiki JSON object.
+
+### 2. Edit Snippet Based on Wiki Change
+
+Input: an updated wiki entry. The model updates existing sentences in a snippet to match the new information.
+
+### 3. Extend Existing Wiki Entry
+
+Input: a snippet referencing a known term. The model adds additional detail to that term in the wiki.
+
+### 4. Number and Source Long Passage
+
+Input: a long passage of prose. The model outputs the passage with numbered sentences and a JSON array mapping numbers to sources.
+
+### 5. Handle Short Snippet or Single Sentence
+
+Input: one or two sentences. The model returns numbered sentences and indicates whether any wiki updates are required.
+
+### 6. Empty Wiki Initialization
+
+Input: a snippet when the wiki is empty. The model creates initial wiki terms based on the text.
+
+### 7. Dense Wiki With Many Entries
+
+Input: a large wiki JSON and a new snippet. The model determines which existing entries need edits and which new ones to add.
+
+### 8. Find Contradictory Sentences
+
+Input: a changed wiki fact (for example a trait change). The model scans supplied text and returns JSON suggestions from `/api/wiki/suggestions` format indicating which sentences mention the outdated fact and why they should be updated.
+
+Each example should be expanded in actual use with multiple sentences and detailed explanations, but these templates show the required inputs and outputs.
+

--- a/src/components/fiction/SidebarFiction.tsx
+++ b/src/components/fiction/SidebarFiction.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from "react";
 import styles from "./SidebarFiction.module.css";
 import {
-  BookOpen,
   Users,
   MapPin,
   Package,

--- a/src/data/fiction/prologue.md
+++ b/src/data/fiction/prologue.md
@@ -10,6 +10,15 @@ tags:
   - Codex
 ---
 
-In the heart of Rahka, under the perpetual twilight of its three suns, Da Solis, the Celestial Priest of the Solis Verio branch, received unsettling news. A courier, breathless and pale, delivered a scorched data-chip. It spoke of a lost shipment, not of common goods, but of sacred texts, vanished en route from the outer colonies. These weren't mere books; they were the lifeblood of their order, chronicles of the Galactic Wars and star-charts predating the Republic.
+[1] In the heart of Rahka, under the perpetual twilight of its three suns, Da Solis, the Celestial Priest of the Solis Verio branch, received unsettling news.
+[2] A courier, breathless and pale, delivered a scorched data-chip.
+[3] It spoke of a lost shipment, not of common goods, but of sacred texts, vanished en route from the outer colonies.
+[4] These weren't mere books; they were the lifeblood of their order, chronicles of the Galactic Wars and star-charts predating the Republic.
 
-Da Solis's chambers, an opulent office carved into the crystal heart of a mountain, grew silent save for the crackling of the bio-luminescent fireplace. He didn't rage. Instead, a grim smile touched his lips. This was not just a loss; it was a challenge. He would reclaim them. The Prologue to this new chapter of his life was being written, not in ink, but in resolve. He dismissed the courier, his gaze already distant, plotting a course through treacherous star systems, perhaps even to the rugged terrains of Garantuam if need be.
+[5] Da Solis's chambers, an opulent office carved into the crystal heart of a mountain, grew silent save for the crackling of the bio-luminescent fireplace.
+[6] He didn't rage.
+[7] Instead, a grim smile touched his lips.
+[8] This was not just a loss; it was a challenge.
+[9] He would reclaim them.
+[10] The Prologue to this new chapter of his life was being written, not in ink, but in resolve.
+[11] He dismissed the courier, his gaze already distant, plotting a course through treacherous star systems, perhaps even to the rugged terrains of Garantuam if need be.

--- a/src/data/wiki/terms.json
+++ b/src/data/wiki/terms.json
@@ -1,30 +1,26 @@
 {
-  "Da Solis": {
-    "description": "Da Solis is the Celestial Priest of the Solis Verio branch, based on Rahka. Known for his stern demeanor and unwavering dedication to recovering sacred texts.",
+  "Character: Main Protagonist": {
+    "description": "Placeholder for the story's central hero.",
     "category": "Character"
   },
-  "Solis Verio": {
-    "description": "One of the major factions within the Galactic Order, specializing in ancient lore, celestial navigation, and spiritual practices. They have a strong presence on planets like Rahka and Garantuam.",
-    "category": "Faction"
+  "Character: Main Antagonist": {
+    "description": "Placeholder for the primary opposing force.",
+    "category": "Character"
   },
-  "Rahka": {
-    "description": "A planet characterized by its three suns, serving as the spiritual nucleus of the Solis Verio civilization. It's a place of immense knowledge and ancient temples.",
+  "Location: Capital City": {
+    "description": "Major setting of the plot where many events take place.",
     "category": "Location"
   },
-  "Galactic Wars": {
-    "description": "A series of ancient conflicts that shaped the current political landscape of the galaxy, leaving behind remnants of powerful technologies and deep-seated rivalries.",
+  "Object: Mysterious Artifact": {
+    "description": "Important item that drives the narrative forward.",
+    "category": "Object"
+  },
+  "Event: Civil Uprising": {
+    "description": "A pivotal event that changes the world order.",
     "category": "Event"
   },
-  "Celestial Priest": {
-    "description": "A high-ranking title within the Solis Verio, responsible for interpreting celestial events, safeguarding sacred texts, and guiding the spiritual development of its members.",
-    "category": "Title"
-  },
-  "Garantuam": {
-    "description": "A rugged, untamed planet that serves as the militant heart of the Solis Vero. Its harsh landscapes are used for training and defense.",
-    "category": "Location"
-  },
-  "sacred texts": {
-    "description": "Ancient scriptures and documents holding significant religious or historical importance to the Solis Verio.",
-    "category": "Item"
+  "Trait: Impulsive": {
+    "description": "Used to describe a character who acts quickly without planning.",
+    "category": "Trait"
   }
 }

--- a/src/pages/api/wiki/suggestions.ts
+++ b/src/pages/api/wiki/suggestions.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getEditSuggestions } from '../../../utils/wikiProcessor';
+import type { EditSuggestion } from '../../../types';
+
+interface SuggestionRequest {
+  text: string;
+  patterns: {
+    find: string;
+    reason: string;
+    priority?: number;
+    priorityReason?: string;
+  }[];
+}
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ suggestions: EditSuggestion[] } | { message: string }>
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ message: `Method ${req.method} Not Allowed` });
+  }
+
+  const body: SuggestionRequest = req.body;
+  if (!body || typeof body.text !== 'string' || !Array.isArray(body.patterns)) {
+    return res.status(400).json({ message: 'Invalid payload' });
+  }
+
+  const suggestions = getEditSuggestions(body.text, body.patterns);
+  res.status(200).json({ suggestions });
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import Head from 'next/head';
-import { Menu, X, BookOpen } from 'lucide-react';
+import { BookOpen } from 'lucide-react';
 import type { NextPage } from 'next';
 
 import SidebarFiction from '../components/fiction/SidebarFiction';
@@ -115,9 +115,6 @@ const HomePage: NextPage = () => {
     setSelectedTermKey(termKey);
   };
 
-  const toggleMobileMenu = () => {
-    setIsMobileMenuOpen(!isMobileMenuOpen);
-  };
 
   if (isLoading) {
     return <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>Loading editor...</div>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,3 +33,10 @@ export interface HoveredTermInfo {
   x: number;
   y: number;
 }
+
+export interface EditSuggestion {
+  sentence: string;
+  reason: string;
+  priority?: number;
+  priorityReason?: string;
+}

--- a/src/utils/wikiProcessor.ts
+++ b/src/utils/wikiProcessor.ts
@@ -1,0 +1,40 @@
+export function splitIntoSentences(text: string): string[] {
+  return text
+    .replace(/\n+/g, ' ') // replace newlines with spaces
+    .split(/(?<=[.!?])\s+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+export function numberSentences(text: string): { numberedText: string; sentences: { number: number; sentence: string }[] } {
+  const sentences = splitIntoSentences(text);
+  const mapping = sentences.map((sentence, idx) => ({ number: idx + 1, sentence }));
+  const numberedText = mapping.map(m => `[${m.number}] ${m.sentence}`).join(' ');
+  return { numberedText, sentences: mapping };
+}
+
+interface Pattern {
+  find: string | RegExp;
+  reason: string;
+  priority?: number;
+  priorityReason?: string;
+}
+
+export function getEditSuggestions(text: string, patterns: Pattern[]): import('../types').EditSuggestion[] {
+  const sentences = splitIntoSentences(text);
+  const suggestions: import('../types').EditSuggestion[] = [];
+  sentences.forEach((sentence) => {
+    patterns.forEach(pat => {
+      const regex = typeof pat.find === 'string' ? new RegExp(pat.find, 'i') : pat.find;
+      if (regex.test(sentence)) {
+        suggestions.push({
+          sentence,
+          reason: pat.reason,
+          priority: pat.priority,
+          priorityReason: pat.priorityReason,
+        });
+      }
+    });
+  });
+  return suggestions;
+}


### PR DESCRIPTION
## Summary
- restructure placeholder wiki terms
- add sentence numbering to prologue example
- implement wiki processing utilities
- provide API endpoint for edit suggestions
- document wiki workflow and prompts
- clean unused imports and update README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842143afdec8333b3887ce0c781a1e0