### PR TITLE
Add wiki processing utilities

### DIFF
--- a/docs/WikiProcessing.md
+++ b/docs/WikiProcessing.md
@@ -1,0 +1,72 @@
+# Wiki Processing Guide
+
+This document explains how to structure the story wiki and how language models should interact with it.
+
+## 1. Sentence Numbering
+- Every sentence in the main markdown file should begin with a numeric identifier in brackets, e.g. `[1]`.
+- Sources or notes should reference these numbers rather than quoting text directly.
+
+## 2. Wiki Structure
+The wiki is stored in `src/data/wiki/terms.json`. It should remain machine-friendly and organized into categories.
+
+```json
+{
+  "Characters": {},
+  "Locations": {},
+  "Objects": {},
+  "CharacterTraits": {},
+  "Factions": {},
+  "Events": {}
+}
+```
+
+Each category maps term names to an object containing a `description` and optional metadata. Avoid using specific fictional names in this guide—focus on describing the categories.
+
+### Non‑fiction Example
+For a biography project, the same structure can be used with categories like `People`, `Places`, `Documents`, etc.
+
+## 3. Processing Workflow
+1. Parse the markdown document and produce an array of numbered sentences.
+2. Compare the snippet or proposed change with the existing wiki data.
+3. Generate JSON instructions describing which sentences to edit or append.
+4. Return the JSON in a consistent format so the front end can handle it.
+
+## 4. JSON Output Schema
+```json
+{
+  "edits": [
+    {
+      "sentence": "<existing sentence text>",
+      "reason": "<why this needs editing>",
+      "priority": 1,
+      "priorityReason": "<context for the priority>"
+    }
+  ]
+}
+```
+The `priority` value ranks how urgently a change should be made (1 is highest). The front end can display or sort these edits accordingly.
+
+## 5. Prompt Library
+Below are example prompts for common scenarios. They assume that the model has access to the wiki terms and a snippet of text.
+
+1. **Update Wiki from Snippet**
+   - *Long Snippet:* Provide a detailed paragraph describing characters, locations, and items. Ask the model to update or create terms in the wiki categories.
+   - *Short Snippet:* Provide one or two sentences. Ask the model to identify any new terms and add them to the wiki with brief descriptions.
+   - *Empty Wiki:* When no information exists yet, the model should create the initial categories and terms.
+2. **Edit Snippet Based on Wiki**
+   - Instruct the model to check the snippet against existing wiki data and modify conflicting descriptions.
+3. **Edit Wiki After Story Change**
+   - The model reviews changed text and updates relevant wiki entries accordingly.
+4. **Find Contradictory Sentences**
+   - The model scans the numbered sentences and lists any that conflict with wiki facts.
+5. **Suggest Expansion**
+   - Ask for suggestions on where to insert additional context or references within the story.
+6. **Summarize a Long Snippet**
+   - Produce a concise summary referencing sentence numbers.
+7. **Identify Missing Sources**
+   - List sentences that should cite a source but currently do not.
+8. **Generate Edit List**
+   - Return the JSON structure described above, filling in reasons and priority for each sentence.
+
+## 6. Separation from UI
+Processing logic lives in TypeScript under `src/lib/wikiProcessor.ts`. The front end will call these functions through API routes, keeping presentation and processing separated.

--- a/src/components/wiki/SidebarWiki.tsx
+++ b/src/components/wiki/SidebarWiki.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import styles from './SidebarWiki.module.css';
-import { BookOpen, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 import type { WikiTerms } from '../../types';
 
 interface SidebarWikiProps {

--- a/src/data/wiki/template.json
+++ b/src/data/wiki/template.json
@@ -1,0 +1,8 @@
+{
+  "Characters": {},
+  "Locations": {},
+  "Objects": {},
+  "CharacterTraits": {},
+  "Factions": {},
+  "Events": {}
+}

--- a/src/lib/wikiProcessor.ts
+++ b/src/lib/wikiProcessor.ts
@@ -1,0 +1,65 @@
+// src/lib/wikiProcessor.ts
+
+/**
+ * Utility functions for processing wiki data and story text.
+ * These helpers remain independent from the UI so that the
+ * front end can call them via API routes or directly in tests.
+ */
+
+export interface EditSuggestion {
+  sentence: string;
+  reason: string;
+  priority: number;
+  priorityReason: string;
+}
+
+/** Split markdown text into individual sentences. */
+export function extractSentences(markdown: string): string[] {
+  const cleaned = markdown
+    .replace(/\n+/g, ' ') // collapse newlines
+    .replace(/\s+/g, ' ')  // normalize spaces
+    .trim();
+  if (!cleaned) return [];
+  return cleaned
+    .split(/(?<=[.!?])\s+/)
+    .filter(s => s.length > 0);
+}
+
+/**
+ * Prefix each sentence with its index starting at 1.
+ * Returns an array of numbered sentences.
+ */
+export function numberSentences(sentences: string[]): string[] {
+  return sentences.map((s, i) => `[${i + 1}] ${s.trim()}`);
+}
+
+/**
+ * Generate a list of edit suggestions based on search terms.
+ * This is a very simple implementation intended as an example.
+ * For each term provided in the `updates` object, all sentences
+ * containing that term are flagged.
+ */
+export function generateEditList(
+  sentences: string[],
+  updates: Record<string, string>
+): EditSuggestion[] {
+  const edits: EditSuggestion[] = [];
+  Object.keys(updates).forEach(term => {
+    sentences.forEach(s => {
+      if (s.toLowerCase().includes(term.toLowerCase())) {
+        edits.push({
+          sentence: s,
+          reason: `Contains term "${term}" which may need update to "${updates[term]}"`,
+          priority: 2,
+          priorityReason: 'Automatic detection based on term match.'
+        });
+      }
+    });
+  });
+  return edits;
+}
+
+/** Convert the edit list to the standard JSON payload. */
+export function toEditPayload(edits: EditSuggestion[]) {
+  return { edits };
+}

--- a/src/pages/api/wiki/process.ts
+++ b/src/pages/api/wiki/process.ts
@@ -1,0 +1,22 @@
+// src/pages/api/wiki/process.ts
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { extractSentences, numberSentences, generateEditList, toEditPayload } from '../../../lib/wikiProcessor';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const { markdown, updates } = req.body as { markdown: string; updates: Record<string, string> };
+  if (typeof markdown !== 'string') {
+    return res.status(400).json({ message: 'markdown string required' });
+  }
+
+  const sentences = extractSentences(markdown);
+  const numbered = numberSentences(sentences);
+  const edits = generateEditList(sentences, updates || {});
+
+  res.status(200).json({ numbered, ...toEditPayload(edits) });
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,7 @@ const HomePage: NextPage = () => {
   const [selectedTermKey, setSelectedTermKey] = useState<string | null>(null);
   const [isTooltipVisible, setIsTooltipVisible] = useState<boolean>(false);
   const [isWikiOpen, setIsWikiOpen] = useState<boolean>(false);
-  const [activeSidebarTab, setActiveSidebarTab] = useState<'fiction' | 'wiki'>('fiction');
+  const [activeSidebarTab, setActiveSidebarTab] = useState<'editor' | 'wiki'>('editor');
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const fetchFictionContent = async () => {


### PR DESCRIPTION
## Summary
- document wiki processing and prompt examples
- add template for structured wiki categories
- provide TypeScript helper for numbering sentences and generating edit lists
- expose API route for processing wiki markdown
- clean up a few lint issues

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842197585ac83339fc8e7f248943a5d