### PR TITLE
Enable editing by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.513.0",
+        "marked": "^15.0.12",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -4331,6 +4332,18 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.513.0",
+    "marked": "^15.0.12",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/wiki/SidebarWiki.tsx
+++ b/src/components/wiki/SidebarWiki.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import styles from './SidebarWiki.module.css';
-import { BookOpen, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 import type { WikiTerms } from '../../types';
 
 interface SidebarWikiProps {


### PR DESCRIPTION
## Summary
- start EditorAreaFiction in editing mode
- use a contentEditable `<div>` to edit rich text
- add `marked` dependency for initial HTML rendering

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68421a040dbc8331a8e3975b952dc214