### PR TITLE
Fix wiki term loading and sidebar issues

### DIFF
--- a/src/components/fiction/EditorAreaFiction.tsx
+++ b/src/components/fiction/EditorAreaFiction.tsx
@@ -122,7 +122,7 @@ const EditorAreaFiction: React.FC<EditorAreaFictionProps> = ({
 
       if (term) {
         const handleEnter = (e: React.MouseEvent<HTMLSpanElement>) => {
-          onTermHover(term, e.clientX, e.clientY, 'purple');
+          onTermHover(term, e.clientX, e.clientY, 'purple', '');
         };
         const handleClick = () => onTermClick?.(term);
         return (

--- a/src/components/fiction/SidebarFiction.tsx
+++ b/src/components/fiction/SidebarFiction.tsx
@@ -15,13 +15,13 @@ import {
 import terms from "../../data/terms.json";
 
 interface Term {
+  text: string;
   description: string;
   category: string;
+  preceding?: string;
 }
 
-interface TermsData {
-  [key: string]: Term;
-}
+type TermsData = Term[];
 
 interface SidebarFictionProps {
   isMobileMenuOpen: boolean;
@@ -50,17 +50,15 @@ const SidebarFiction: React.FC<SidebarFictionProps> = ({
 }) => {
   // Process terms data
   const termsData: TermsData = terms;
-  
+
   // Get unique categories from the data
-  const categories = [...new Set(Object.values(termsData).map(term => term.category))];
-  
+  const categories = [...new Set(termsData.map(term => term.category))];
+
   // Create categorized terms object
   const categorizedTerms = categories.reduce((acc, category) => {
-    acc[category] = Object.entries(termsData).filter(([_, term]) => 
-      term.category === category
-    );
+    acc[category] = termsData.filter(term => term.category === category);
     return acc;
-  }, {} as Record<string, [string, Term][]>);
+  }, {} as Record<string, Term[]>);
 
   // Define each accordion section with actual counts and appropriate icons
   const navItems = categories.map(category => ({
@@ -136,9 +134,9 @@ const SidebarFiction: React.FC<SidebarFictionProps> = ({
                 }
               >
                 <ul className={styles.itemList}>
-                  {item.items.map(([termName, termData]) => (
-                    <li 
-                      key={termData.text} 
+                  {item.items.map(termData => (
+                    <li
+                      key={termData.text}
                       className={`${styles.itemListEntry} ${selectedTermKey === termData.text ? styles.activeItem : ''}`}
                       onClick={() => onSelectTerm(termData.text)}
                       role="button"

--- a/src/components/wiki/SidebarWiki.tsx
+++ b/src/components/wiki/SidebarWiki.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import styles from './SidebarWiki.module.css';
-import { BookOpen, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 import type { WikiTerms } from '../../types';
 
 interface SidebarWikiProps {
@@ -17,9 +17,11 @@ const SidebarWiki: React.FC<SidebarWikiProps> = ({ terms, onSelectTerm, selected
 
   // reindex terms based on key "text"-id where id is index of term
 
-  const filteredTerms = terms.filter(term => 
+  const filteredTerms = terms
+    .filter(term =>
       term.category.toLowerCase().includes(searchTerm.toLowerCase())
-  ).sort();
+    )
+    .sort((a, b) => a.text.localeCompare(b.text));
 
   console.log(filteredTerms);
 
@@ -40,9 +42,9 @@ const SidebarWiki: React.FC<SidebarWikiProps> = ({ terms, onSelectTerm, selected
       </div>
       <nav className={styles.navList}>
         {filteredTerms.length > 0 ? (
-          filteredTerms.map(term => (
+          filteredTerms.map((term, idx) => (
             <button
-              key={term.text}
+              key={`${term.text}-${idx}`}
               className={`${styles.navItem} ${term.text === selectedTermKey ? styles.navItemActive : ''}`}
               onClick={() => onSelectTerm(term.text)}
             >

--- a/src/components/wiki/WikiEditor.tsx
+++ b/src/components/wiki/WikiEditor.tsx
@@ -92,14 +92,15 @@ const WikiEditor: React.FC<WikiEditorProps> = ({ terms, selectedTermKey, onSave,
   };
 
   const handleDelete = async () => {
-    if (!selectedTermKey || !terms[selectedTermKey]) return;
+    const index = terms.findIndex(term => term.text === selectedTermKey);
+    if (!selectedTermKey || index === -1) return;
     if (confirm(`Are you sure you want to delete "${selectedTermKey}"?`)) {
-      const updatedTerms = [ ...terms ];
-      updatedTerms.splice(updatedTerms.findIndex(term => term.text === selectedTermKey), 1);
+      const updatedTerms = [...terms];
+      updatedTerms.splice(index, 1);
       const success = await onSave(updatedTerms);
       if (success) {
         setTerms(updatedTerms);
-        onSelectTerm(updatedTerms[0].text || null);
+        onSelectTerm(updatedTerms[0]?.text || null);
       }
     }
   };
@@ -112,7 +113,7 @@ const WikiEditor: React.FC<WikiEditorProps> = ({ terms, selectedTermKey, onSave,
       setCurrentTerm(hasTerm.text);
       setCurrentDescription(hasTerm.description);
       setCurrentCategory(hasTerm.category);
-      setCurrentPreceding(hasTerm.preceding);
+      setCurrentPreceding(hasTerm.preceding || '');
     } else {
       setCurrentTerm('');
       setCurrentDescription('');

--- a/src/pages/api/fiction/content.ts
+++ b/src/pages/api/fiction/content.ts
@@ -6,7 +6,7 @@ import matter from 'gray-matter';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { FictionData, Frontmatter } from '../../../types';
 
-import { create_client, generate_struct, generate_errors } from '../index';
+import { create_client, generate_struct } from '../index';
 
 type ErrorResponse = {
   message: string;
@@ -30,7 +30,7 @@ export default async function handler(
       const wordCount = content.split(/\s+/).filter(Boolean).length;
 
       const client = await create_client();
-      const struct = await generate_struct(client, content, structFilePath);
+      await generate_struct(client, content, structFilePath);
 
       res.status(200).json({ frontmatter: data as Frontmatter, markdownContent: content, wordCount });
     } catch (error) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,7 +15,7 @@ const HomePage: NextPage = () => {
   const [fictionData, setFictionData] = useState<FictionData>({ frontmatter: {}, markdownContent: '', wordCount: 0 });
   const [knownTerms, setKnownTerms] = useState<KnownTerms>({});
   const [hoveredTermInfo, setHoveredTermInfo] = useState<HoveredTermInfo | null>(null);
-  const [wikiTerms, setWikiTerms] = useState<WikiTerms>({});
+  const [wikiTerms, setWikiTerms] = useState<WikiTerms>([]);
   const [selectedTermKey, setSelectedTermKey] = useState<string | null>(null);
   const [isTooltipVisible, setIsTooltipVisible] = useState<boolean>(false);
   const [isWikiOpen, setIsWikiOpen] = useState<boolean>(false);
@@ -38,11 +38,16 @@ const HomePage: NextPage = () => {
       const res = await fetch('/api/wiki/terms');
       if (!res.ok) throw new Error('Failed to fetch wiki terms');
       const termsData: WikiTerms = await res.json();
-      setWikiTerms(termsData);
+      const validTerms = termsData.filter(
+        t => t.text && t.description && t.category
+      );
+      const uniqueTerms = validTerms.filter(
+        (t, idx, arr) => arr.findIndex(tt => tt.text === t.text) === idx
+      );
+      setWikiTerms(uniqueTerms);
       const formatted: KnownTerms = {};
-      console.log('termsData', termsData);
-      for (const term in termsData) {
-        formatted[termsData[term].text] = termsData[term].description;
+      for (const term of uniqueTerms) {
+        formatted[term.text] = term.description;
       }
       setKnownTerms(formatted);
     } catch (error) {
@@ -81,13 +86,20 @@ const HomePage: NextPage = () => {
       });
       if (!res.ok) throw new Error('Failed to save terms');
       const result = await res.json();
-      setWikiTerms(result.terms);
+      const resultTerms: WikiTerms = result.terms;
+      const validTerms = resultTerms.filter(
+        t => t.text && t.description && t.category
+      );
+      const uniqueTerms = validTerms.filter(
+        (t, idx, arr) => arr.findIndex(tt => tt.text === t.text) === idx
+      );
+      setWikiTerms(uniqueTerms);
       const formatted: KnownTerms = {};
-      for (const term in result.terms) {
-        formatted[result.terms[term].text] = result.terms[term].description;
+      for (const term of uniqueTerms) {
+        formatted[term.text] = term.description;
       }
       console.log('updatedTerms', updatedTerms);
-      console.log('wikiTerms', result.terms);
+      console.log('wikiTerms', uniqueTerms);
       console.log('formatted', formatted);
       setKnownTerms(formatted);
       alert('Wiki terms saved!');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,14 +13,14 @@ export interface FictionData {
   wordCount: number;
 }
 
-export interface TermData {
+export interface WikiTerm {
+  text: string;
   description: string;
   category: string;
+  preceding?: string;
 }
 
-export interface WikiTerms {
-  [key: string]: TermData;
-}
+export type WikiTerms = WikiTerm[];
 
 // Used for the simpler key:description mapping in the fiction editor
 export interface KnownTerms {


### PR DESCRIPTION
## Summary
- update `WikiTerms` typing to work with arrays
- filter and dedupe wiki term lists
- render sidebar wiki with stable ordering and unique keys
- fix wiki editor delete logic and optional preceding field
- adjust API to validate arrays of wiki terms
- sync SidebarFiction with array-based terms
- update editor hover handler

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module './config')*

------
https://chatgpt.com/codex/tasks/task_e_6842fdf88a988333b3abbd9ed700fa76