### PR TITLE
Fix wiki terms persistence

### DIFF
--- a/src/pages/api/wiki/terms.ts
+++ b/src/pages/api/wiki/terms.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { WikiTerms } from '../../../types';
 
-import { create_client, generate_struct, generate_errors } from '../index';
+import { create_client, generate_errors } from '../index';
 
 type ErrorResponse = {
   message: string;
@@ -47,7 +47,9 @@ export default async function handler(
       const struct1 = JSON.parse(fs.readFileSync(termsFilePath, 'utf8'));
       const struct2 = JSON.parse(fs.readFileSync(newTermsFilePath, 'utf8'));
       const inputText = fs.readFileSync(inputTextFilePath, 'utf8');
-      const errors = await generate_errors(client, inputText, struct1, struct2, errorsFilePath);
+      await generate_errors(client, inputText, struct1, struct2, errorsFilePath);
+      // Persist the new terms so subsequent GET requests return the updated data
+      fs.writeFileSync(termsFilePath, JSON.stringify(newTerms, null, 2), 'utf8');
       res.status(200).json({ message: 'Wiki terms saved successfully', terms: newTerms });
     } catch (error) {
       console.error('Error saving wiki terms:', error);


### PR DESCRIPTION
## Summary
- ensure updated wiki terms persist across reloads by writing to `terms.json`

## Testing
- `npm run lint` *(fails: prefer-const, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68431f4cf1f88333af75a82b130f1e8c